### PR TITLE
get go version from go.mod file

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version-file: 'go.mod'
+        check-latest: true
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Updates the `setup-go` action in  `go-build.yml` to get the go version from the `go.mod` file.

Resolves issue #10 