### PR TITLE
chore: add devcontainer and Makefile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "terrahash - Development",
+	//https://mcr.microsoft.com/en-us/product/devcontainers/go/tags
+	"image": "mcr.microsoft.com/devcontainers/go:1.22-bullseye",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/terraform:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"golang.go",
+				"HashiCorp.terraform",
+				"ms-vscode.makefile-tools"
+			]
+		},
+		"codespaces": {}
+	},
+	"hostRequirements": {
+		"memory": "4gb"
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	"remoteUser": "vscode"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+default: build
+
+SETENV=
+ifeq ($(OS),Windows_NT)
+	SETENV=set
+endif
+
+build:
+	go build -v ./...
+
+install: build
+	go install -v ./...
+
+lint:
+	golangci-lint run
+
+fmt:
+	gofmt -s -w -e .
+
+test:
+	go test -v -cover -tags=all -timeout=300s -parallel=4 ./...
+
+.PHONY: build install lint generate fmt test


### PR DESCRIPTION
As this project is adressing and solving a very important topic in the Terraform ecosystem, I think it would be valuable to make contributions as easy as possible. This PR should help developers to get started with the CLI as wel as with contributing to the CLI ba adding two features:

- a `devcontainer` definition to enable the development in a devcontainer so that no local setup is needed (except for having Docker and VSCode up and running). This would also enbale the usage of GitHub Codespaces
- a `Makefile` that comprises the most important commands especially for code contributions 